### PR TITLE
Fix potential vulnerability that may allow unrestricted write access

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ const verifyIdentity = async identity => {
     const payload = u8a.toString(u8a.fromString(data, 'base16'), 'base64url')
     const [header, signature] = signatures.publicKey.split('..')
     const jws = [header, payload, signature].join('.')
-    didResolver.verifyJWS(jws)
+    
+    await didResolver.verifyJWS(jws)
       .then(({ didResolutionResult }) => {
         const { id: idFromSignature } = didResolutionResult.didDocument
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const verifyIdentity = async identity => {
     const payload = u8a.toString(u8a.fromString(data, 'base16'), 'base64url')
     const [header, signature] = signatures.publicKey.split('..')
     const jws = [header, payload, signature].join('.')
-    
+
     await didResolver.verifyJWS(jws)
       .then(({ didResolutionResult }) => {
         const { id: idFromSignature } = didResolutionResult.didDocument

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -107,10 +107,10 @@ describe('DID Identity Provider', function () {
       }), keystore })
 
       // The ID of the fake identity is equal to the ID of an admin
-      // account, however all the signatures and the hash is different,
-      // meaning that in the entries produced by the fake identity the "identity"
+      // account, but all the signatures and the hash are different.
+      // This means that the entries produced by the fake identity's "identity"
       // field will point to a fake identity document in IPFS and the victim
-      // will get that faked identity object
+      // will get a fake identity object.
       assert.strictEqual(fakeIdentity.id, identity.id)
       assert.notStrictEqual(fakeIdentity.hash, identity.hash)
       assert.notDeepStrictEqual(fakeIdentity.signatures, identity.signatures)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -99,7 +99,7 @@ describe('DID Identity Provider', function () {
       const fakeIdentities = await Identities({ keystore: fakeKeystore })
 
       // Create an identity with all new keys, but with an ID from the 
-      // "admin" identity we wanna use to get write access by utilizing
+      // "admin" identity we want to use to get write access by utilizing
       // a modified version of the provider
       const fakeIdentity =  await fakeIdentities.createIdentity({ provider: () => ({
         ...fakeProvider,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -81,8 +81,43 @@ describe('DID Identity Provider', function () {
     })
 
     it('DID identity with incorrect id does not verify', async () => {
-      const identity2 = { id: 'NotAnId', publicKey: identity.publicKey, signatures: identity.signatures, type: identity.type, sign: identities.sign, verify: identities.verify }
+      const identity2 = { 
+        ...identity,
+        id: 'NotAnId', 
+      }
       const verified = await identities.verifyIdentity(identity2)
+      assert.strictEqual(verified, false)
+    })
+
+    it('Valid DID identity with fake publicKey does not verify', async () => {
+      // HACKER part:
+      // Create a completely new set of private keys
+      const fakeSeed = new Uint8Array([100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 183, 177, 123, 238, 83, 240, 143, 188, 87, 191, 33, 95, 58, 136, 46, 218, 219, 245])
+      const fakeDidProvider = new Ed25519Provider(fakeSeed)
+      const fakeProvider = await DIDIdentityProvider({ didProvider: fakeDidProvider })();
+      const fakeKeystore = await KeyStore({ path: path.join(keypath, 'fake') })
+      const fakeIdentities = await Identities({ keystore: fakeKeystore })
+
+      // Create an identity with all new keys, but with an ID from the 
+      // "admin" identity we wanna use to get write access by utilizing
+      // a modified version of the provider
+      const fakeIdentity =  await fakeIdentities.createIdentity({ provider: () => ({
+        ...fakeProvider,
+        getId: () => identity.id,
+      }), keystore })
+
+      // The ID of the fake identity is equal to the ID of an admin
+      // account, however all the signatures and the hash is different,
+      // meaning that in the entries produced by the fake identity the "identity"
+      // field will point to a fake identity document in IPFS and the victim
+      // will get that faked identity object
+      assert.strictEqual(fakeIdentity.id, identity.id)
+      assert.notStrictEqual(fakeIdentity.hash, identity.hash)
+      assert.notDeepStrictEqual(fakeIdentity.signatures, identity.signatures)
+
+      // VICTIM part:
+      // Using a normal didProvider try to validate the faked identity
+      const verified = await identities.verifyIdentity(fakeIdentity)
       assert.strictEqual(verified, false)
     })
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -81,9 +81,9 @@ describe('DID Identity Provider', function () {
     })
 
     it('DID identity with incorrect id does not verify', async () => {
-      const identity2 = { 
+      const identity2 = {
         ...identity,
-        id: 'NotAnId', 
+        id: 'NotAnId'
       }
       const verified = await identities.verifyIdentity(identity2)
       assert.strictEqual(verified, false)
@@ -94,17 +94,20 @@ describe('DID Identity Provider', function () {
       // Create a completely new set of private keys
       const fakeSeed = new Uint8Array([100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 183, 177, 123, 238, 83, 240, 143, 188, 87, 191, 33, 95, 58, 136, 46, 218, 219, 245])
       const fakeDidProvider = new Ed25519Provider(fakeSeed)
-      const fakeProvider = await DIDIdentityProvider({ didProvider: fakeDidProvider })();
+      const fakeProvider = await DIDIdentityProvider({ didProvider: fakeDidProvider })()
       const fakeKeystore = await KeyStore({ path: path.join(keypath, 'fake') })
       const fakeIdentities = await Identities({ keystore: fakeKeystore })
 
-      // Create an identity with all new keys, but with an ID from the 
+      // Create an identity with all new keys, but with an ID from the
       // "admin" identity we want to use to get write access by utilizing
       // a modified version of the provider
-      const fakeIdentity =  await fakeIdentities.createIdentity({ provider: () => ({
-        ...fakeProvider,
-        getId: () => identity.id,
-      }), keystore })
+      const fakeIdentity = await fakeIdentities.createIdentity({
+        provider: () => ({
+          ...fakeProvider,
+          getId: () => identity.id
+        }),
+        keystore
+      })
 
       // The ID of the fake identity is equal to the ID of an admin
       // account, but all the signatures and the hash are different.


### PR DESCRIPTION
While researching the DIDs and the way it is integrated to OrbitDB I found that the DID (`did:key:1234`) that is stored as an ID of the Identity object is not validated in any way in the `verifyIdentity` function of a provider, which makes it possible to create a fake identity that is pretending as an admin identity with write access (with the same DID in the ID field of the identity), however generated with entirely new randomly generated set of private keys.

The fix is simple – validate that that ID from the identity is equal to the id from the JWS header in the `verifyIdentity` function.